### PR TITLE
Fix image embed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ Pour utiliser l'extension, glissez le bloc "Contrôle moteur" dans votre cinéma
     
 # Exemple
 <br />
+
 ![alt tag](https://github.com/paulcoiffier/mblock_motor_extension/blob/master/screenshot.png)


### PR DESCRIPTION
Prior to this change the image was not being displayed in README.md.
This issue might have been caused by a recent change in GitHub's
Markdown interpreter, which now strictly enforces the GFM spec. This has
caused some Markdown to no longer work.

README.md as it appears without this fix:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/25029001/ea7d54fe-206d-11e7-9f3a-a3ce52b2f085.png)
